### PR TITLE
Use timerfd for timeouts in socket_stream

### DIFF
--- a/src/NetherGames/Quiche/bindings/generate.php
+++ b/src/NetherGames/Quiche/bindings/generate.php
@@ -29,7 +29,7 @@ if(!file_exists($quichePHPFile)){
     file_put_contents($quichePHPFile, "<?php declare(strict_types=1);\n" . $quiche->compile('NetherGames\Quiche\bindings\Quiche', ($argv[2] ?? "") === "dev"));
 }
 
-if (!file_exists($timerFdPHPFile)) {
+if(!file_exists($timerFdPHPFile)){
     $timerHFile = getenv("TIMERFD_H_FILE");
     if($timerHFile === false || !is_file($timerHFile)){
         $timerHFile = __DIR__ . "/timerfd.h";

--- a/src/NetherGames/Quiche/bindings/generate.php
+++ b/src/NetherGames/Quiche/bindings/generate.php
@@ -7,6 +7,11 @@ if($quichePHPFile === false){
     $quichePHPFile = __DIR__ . "/quiche.php";
 }
 
+$timerFdPHPFile = getenv("TIMERFD_PHP_FILE");
+if($timerFdPHPFile === false){
+    $timerFdPHPFile = __DIR__ . "/timerfd.php";
+}
+
 if(!file_exists($quichePHPFile)){
     $quichePath = getenv("QUICHE_PATH");
     if($quichePath === false || !is_file($quichePath)){
@@ -24,4 +29,15 @@ if(!file_exists($quichePHPFile)){
     file_put_contents($quichePHPFile, "<?php declare(strict_types=1);\n" . $quiche->compile('NetherGames\Quiche\bindings\Quiche', ($argv[2] ?? "") === "dev"));
 }
 
+if (!file_exists($timerFdPHPFile)) {
+    $timerHFile = getenv("TIMERFD_H_FILE");
+    if($timerHFile === false || !is_file($timerHFile)){
+        $timerHFile = __DIR__ . "/timerfd.h";
+    }
+
+    $timerfd = (new FFIMe(FFIME::LIBC))->include($timerHFile);
+    file_put_contents($timerFdPHPFile, "<?php declare(strict_types=1);\n" . $timerfd->compile('NetherGames\Quiche\bindings\timer\TimerFd'));
+}
+
 require $quichePHPFile;
+require $timerFdPHPFile;

--- a/src/NetherGames/Quiche/bindings/timerfd.h
+++ b/src/NetherGames/Quiche/bindings/timerfd.h
@@ -1,0 +1,22 @@
+#define TFD_TIMER_ABSTIME (1 << 0)
+#define TFD_CLOEXEC 02000000
+#define TFD_NONBLOCK 00004000
+#define CLOCK_MONOTONIC 1
+
+typedef long time_t;
+
+struct timespec {
+    time_t tv_sec;
+    long tv_nsec;
+};
+
+struct itimerspec {
+    struct timespec it_interval;
+    struct timespec it_value;
+};
+
+int timerfd_create(int clockid, int flags);
+int timerfd_settime(int fd, int flags, const struct itimerspec *new_value, struct itimerspec *old_value);
+int timerfd_gettime(int fd, struct itimerspec *curr_value);
+int close(int fd);
+long read(int fd, void *buf, long count);

--- a/src/NetherGames/Quiche/io/TimerFd.php
+++ b/src/NetherGames/Quiche/io/TimerFd.php
@@ -2,15 +2,14 @@
 
 namespace NetherGames\Quiche\io;
 
-use NetherGames\Quiche\bindings\timer\TimerFd as TimerFdBindings;
 use NetherGames\Quiche\bindings\timer\int_ptr;
 use NetherGames\Quiche\bindings\timer\struct_itimerspec_ptr;
+use NetherGames\Quiche\bindings\timer\TimerFd as TimerFdBindings;
 use NetherGames\Quiche\bindings\timer\TimerFdFFI;
 use NetherGames\Quiche\socket\QuicheSocket;
 use RuntimeException;
 
-class TimerFd
-{
+class TimerFd{
     public const TFD_TIMER_ABSTIME = (1 << 0);
 
     /** @var TimerFdFFI */
@@ -24,18 +23,18 @@ class TimerFd
     /** @var struct_itimerspec_ptr */
     private struct_itimerspec_ptr $timer;
 
-    public function __construct(QuicheSocket $instance)
-    {
-        // TimerFd is not supported on other platforms than Linux
-        if (php_uname("s") !== 'Linux') return;
+    public function __construct(QuicheSocket $instance){
+        if(php_uname("s") !== 'Linux'){
+            return;
+        }
 
         $this->ffi = TimerFdBindings::ffi();
         $this->fd = $this->ffi->timerfd_create(TimerFdBindings::CLOCK_MONOTONIC, TimerFdBindings::TFD_NONBLOCK | TimerFdBindings::TFD_CLOEXEC);
-        if ($this->fd === -1) {
+        if($this->fd === -1){
             throw new RuntimeException("Failed to create timerfd");
         }
 
-        if (!($stream = fopen("php://fd/" . $this->fd, "rb"))) {
+        if(!($stream = fopen("php://fd/" . $this->fd, "rb"))){
             throw new RuntimeException("Failed to open timerfd stream");
         }
 
@@ -48,56 +47,50 @@ class TimerFd
         $this->timer->it_interval->tv_sec = 0;
         $this->timer->it_interval->tv_nsec = 0;
 
-        // Register stream
-        $instance->registerStream($this->getStream(), function (): void {
+        $instance->registerStream($this->getStream(), function() : void{
             $this->read();
         });
     }
 
-    public function setTimeout(int $timeoutMs): void
-    {
-        if ($this->fd === -1) return;
+    public function setTimeout(int $timeoutMs) : void{
+        if($this->fd === -1) return;
 
         $timer = $this->timer;
-        if ($timeoutMs === 0) {
+        if($timeoutMs === 0){
             // Set it to absolute time in the past to trigger immediately
             $timer->it_value->tv_sec = 1;
             $timer->it_value->tv_nsec = 0;
             $flags = self::TFD_TIMER_ABSTIME;
-        } else {
-            $timer->it_value->tv_sec = (int)($timeoutMs / 1000);
+        }else{
+            $timer->it_value->tv_sec = (int) ($timeoutMs / 1000);
             $timer->it_value->tv_nsec = ($timeoutMs % 1000) * 1000000;
             $flags = 0;
         }
 
-        if ($this->ffi->timerfd_settime($this->fd, $flags, $timer, null) === -1) {
+        if($this->ffi->timerfd_settime($this->fd, $flags, $timer, null) === -1){
             throw new RuntimeException("Failed to set timerfd time");
         }
     }
 
-    public function getTimerFdId(): int
-    {
+    public function getTimerFdId() : int{
         return $this->fd;
     }
 
     /**
      * @return resource
      */
-    public function getStream()
-    {
+    public function getStream(){
         return $this->stream;
     }
 
-    private function read(): void
-    {
-        if (isset($this->fd) && $this->fd !== -1) {
+    private function read() : void{
+        if(($this->fd ?? -1) !== -1){
             $this->ffi->read($this->fd, $this->buffer, 8);
         }
     }
 
-    public function close(): void
-    {
-        if (isset($this->fd) && $this->fd !== -1) {
+    public function close() : void{
+        if(($this->fd ?? -1) !== -1){
             $this->ffi->close($this->fd);
             $this->fd = -1;
         }

--- a/src/NetherGames/Quiche/io/TimerFd.php
+++ b/src/NetherGames/Quiche/io/TimerFd.php
@@ -6,38 +6,56 @@ use NetherGames\Quiche\bindings\timer\TimerFd as TimerFdBindings;
 use NetherGames\Quiche\bindings\timer\int_ptr;
 use NetherGames\Quiche\bindings\timer\struct_itimerspec_ptr;
 use NetherGames\Quiche\bindings\timer\TimerFdFFI;
+use NetherGames\Quiche\socket\QuicheSocket;
 use RuntimeException;
 
 class TimerFd
 {
+    public const TFD_TIMER_ABSTIME = (1 << 0);
+
     /** @var TimerFdFFI */
     private TimerFdFFI $ffi;
     /** @var int */
-    private int $fd;
+    private int $fd = -1;
     /** @var resource */
     private $stream;
+    /** @var int_ptr */
+    private int_ptr $buffer;
 
-    public function __construct()
+    public function __construct(QuicheSocket $instance)
     {
+        // TimerFd is not supported on other platforms than Linux
+        if (php_uname("s") !== 'Linux') return;
+
         $this->ffi = TimerFdBindings::ffi();
         $this->fd = $this->ffi->timerfd_create(TimerFdBindings::CLOCK_MONOTONIC, TimerFdBindings::TFD_NONBLOCK | TimerFdBindings::TFD_CLOEXEC);
         if ($this->fd === -1) {
             throw new RuntimeException("Failed to create timerfd");
         }
 
-        $this->stream = fopen("php://fd/" . $this->fd, "rb");
+        $this->buffer = int_ptr::array(8);
+        if (!($stream = fopen("php://fd/" . $this->fd, "rb"))) {
+            throw new RuntimeException("Failed to open timerfd stream");
+        }
+
+        $this->stream = $stream;
+
+        // Register stream
+        $instance->registerStream($this->getStream(), function (): void {
+            $this->read();
+        });
     }
 
     public function setTimeout(int $timeoutMs): void
     {
-        static $TFD_TIMER_ABSTIME = (1 << 0);
+        if ($this->fd === -1) return;
 
         $timer = struct_itimerspec_ptr::array();
         if ($timeoutMs === 0) {
             // Set it to absolute time in the past to trigger immediately
             $timer->it_value->tv_sec = 1;
             $timer->it_value->tv_nsec = 0;
-            $flags = $TFD_TIMER_ABSTIME;
+            $flags = self::TFD_TIMER_ABSTIME;
         } else {
             $timer->it_value->tv_sec = (int)($timeoutMs / 1000);
             $timer->it_value->tv_nsec = ($timeoutMs % 1000) * 1000000;
@@ -57,15 +75,19 @@ class TimerFd
         return $this->fd;
     }
 
+    /**
+     * @return resource
+     */
     public function getStream()
     {
         return $this->stream;
     }
 
-    public function read(): void
+    private function read(): void
     {
-        $buf = int_ptr::array();
-        $this->ffi->read($this->fd, $buf, 8);
+        if (isset($this->fd) && $this->fd !== -1) {
+            $this->ffi->read($this->fd, $this->buffer, 8);
+        }
     }
 
     public function close(): void

--- a/src/NetherGames/Quiche/io/TimerFd.php
+++ b/src/NetherGames/Quiche/io/TimerFd.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace NetherGames\Quiche\io;
+
+use NetherGames\Quiche\bindings\timer\TimerFd as TimerFdBindings;
+use NetherGames\Quiche\bindings\timer\int_ptr;
+use NetherGames\Quiche\bindings\timer\struct_itimerspec_ptr;
+use NetherGames\Quiche\bindings\timer\TimerFdFFI;
+use RuntimeException;
+
+class TimerFd
+{
+    /** @var TimerFdFFI */
+    private TimerFdFFI $ffi;
+    /** @var int */
+    private int $fd;
+    /** @var resource */
+    private $stream;
+
+    public function __construct()
+    {
+        $this->ffi = TimerFdBindings::ffi();
+        $this->fd = $this->ffi->timerfd_create(TimerFdBindings::CLOCK_MONOTONIC, TimerFdBindings::TFD_NONBLOCK | TimerFdBindings::TFD_CLOEXEC);
+        if ($this->fd === -1) {
+            throw new RuntimeException("Failed to create timerfd");
+        }
+
+        $this->stream = fopen("php://fd/" . $this->fd, "rb");
+    }
+
+    public function setTimeout(int $timeoutMs): void
+    {
+        static $TFD_TIMER_ABSTIME = (1 << 0);
+
+        $timer = struct_itimerspec_ptr::array();
+        if ($timeoutMs === 0) {
+            // Set it to absolute time in the past to trigger immediately
+            $timer->it_value->tv_sec = 1;
+            $timer->it_value->tv_nsec = 0;
+            $flags = $TFD_TIMER_ABSTIME;
+        } else {
+            $timer->it_value->tv_sec = (int)($timeoutMs / 1000);
+            $timer->it_value->tv_nsec = ($timeoutMs % 1000) * 1000000;
+            $flags = 0;
+        }
+
+        $timer->it_interval->tv_sec = 0;
+        $timer->it_interval->tv_nsec = 0;
+
+        if ($this->ffi->timerfd_settime($this->fd, $flags, $timer, null) === -1) {
+            throw new RuntimeException("Failed to set timerfd time");
+        }
+    }
+
+    public function getTimerFdId(): int
+    {
+        return $this->fd;
+    }
+
+    public function getStream()
+    {
+        return $this->stream;
+    }
+
+    public function read(): void
+    {
+        $buf = int_ptr::array();
+        $this->ffi->read($this->fd, $buf, 8);
+    }
+
+    public function close(): void
+    {
+        if (isset($this->fd) && $this->fd !== -1) {
+            $this->ffi->close($this->fd);
+            $this->fd = -1;
+        }
+    }
+}

--- a/src/NetherGames/Quiche/io/TimerFd.php
+++ b/src/NetherGames/Quiche/io/TimerFd.php
@@ -21,6 +21,8 @@ class TimerFd
     private $stream;
     /** @var int_ptr */
     private int_ptr $buffer;
+    /** @var struct_itimerspec_ptr */
+    private struct_itimerspec_ptr $timer;
 
     public function __construct(QuicheSocket $instance)
     {
@@ -33,12 +35,18 @@ class TimerFd
             throw new RuntimeException("Failed to create timerfd");
         }
 
-        $this->buffer = int_ptr::array(8);
         if (!($stream = fopen("php://fd/" . $this->fd, "rb"))) {
             throw new RuntimeException("Failed to open timerfd stream");
         }
 
         $this->stream = $stream;
+
+        // Initialize timer and buffer once; it_interval defines how often the timer should trigger,
+        // while it_value defines when the timer should trigger next (We don't want the timer to restart in an interval)
+        $this->buffer = int_ptr::array(8);
+        $this->timer = struct_itimerspec_ptr::array();
+        $this->timer->it_interval->tv_sec = 0;
+        $this->timer->it_interval->tv_nsec = 0;
 
         // Register stream
         $instance->registerStream($this->getStream(), function (): void {
@@ -50,7 +58,7 @@ class TimerFd
     {
         if ($this->fd === -1) return;
 
-        $timer = struct_itimerspec_ptr::array();
+        $timer = $this->timer;
         if ($timeoutMs === 0) {
             // Set it to absolute time in the past to trigger immediately
             $timer->it_value->tv_sec = 1;
@@ -61,9 +69,6 @@ class TimerFd
             $timer->it_value->tv_nsec = ($timeoutMs % 1000) * 1000000;
             $flags = 0;
         }
-
-        $timer->it_interval->tv_sec = 0;
-        $timer->it_interval->tv_nsec = 0;
 
         if ($this->ffi->timerfd_settime($this->fd, $flags, $timer, null) === -1) {
             throw new RuntimeException("Failed to set timerfd time");

--- a/src/NetherGames/Quiche/socket/QuicheSocket.php
+++ b/src/NetherGames/Quiche/socket/QuicheSocket.php
@@ -15,15 +15,17 @@ use NetherGames\Quiche\QuicheConnection;
 use NetherGames\Quiche\SocketAddress;
 use RuntimeException;
 use Socket;
+use Throwable;
 use function array_values;
 use function min;
 use function socket_bind;
 use function socket_close;
 use function socket_create;
 use function socket_last_error;
-use function socket_select;
+use function socket_set_nonblock;
 use function socket_strerror;
 use function spl_object_id;
+use function usleep;
 use const SOCK_DGRAM;
 use const SOL_UDP;
 
@@ -158,25 +160,27 @@ abstract class QuicheSocket{
     abstract public function setNonWritableSocket(int $socketId) : void;
 
     public function selectSockets(?int $timeout = null) : void{
-        $read = $this->sockets;
-        $write = $this->nonWritableSockets;
-        $except = null;
+        foreach($this->nonWritableCallbacks as $closure){
+            try {
+                $closure();
+            }catch (Throwable){}
+        }
+        foreach($this->socketCallbacks as $closure){
+            try {
+                $closure();
+            }catch (Throwable){}
+        }
 
         $timerWait = $this->timer->manage();
-        if ($timeout === null) {
+        if($timeout === null){
             $timeout = $timerWait;
-        } elseif ($timerWait !== null) {
+        }elseif($timerWait !== null){
             $timeout = min($timerWait, $timeout);
         }
 
-        $select = socket_select($read, $write, $except, $timeout === null ? null : 0, $timeout ?? 0);
-        if($select !== false && $select > 0){
-            foreach($write as $socketId => $socket){
-                $this->nonWritableCallbacks[$socketId]();
-            }
-            foreach($read as $socketId => $socket){
-                $this->socketCallbacks[$socketId]();
-            }
+        $timeout = min($timeout, 100);
+        if($timeout !== null && $timeout > 0){
+            usleep($timeout * 1000);
         }
 
         $this->handleOutgoing();
@@ -219,6 +223,8 @@ abstract class QuicheSocket{
         if(isset($this->nonWritableSockets[$socketId = spl_object_id($socket)])){
             return false;
         }
+
+        socket_set_nonblock($socket);
 
         $this->sockets[$socketId] = $socket;
         $this->socketCallbacks[$socketId] = $callback;

--- a/src/NetherGames/Quiche/socket/QuicheSocket.php
+++ b/src/NetherGames/Quiche/socket/QuicheSocket.php
@@ -69,7 +69,6 @@ abstract class QuicheSocket{
             $connection->onTimeout();
         });
 
-        // File descriptor timer
         $this->timerFd = new TimerFd($this);
 
         if($enableDebugLogging){
@@ -173,20 +172,20 @@ abstract class QuicheSocket{
         $except = null;
 
         $timerWait = $this->timer->manage();
-        if ($timeout === null) {
+        if($timeout === null){
             $timeout = $timerWait;
-        } elseif ($timerWait !== null) {
+        }elseif($timerWait !== null){
             $timeout = min($timerWait, $timeout);
         }
 
-        if ($this->timerFd->getTimerFdId() !== -1) {
+        if($this->timerFd->getTimerFdId() !== -1){
             // Set timeout for the file descriptor. Instead of using stream_select for sleep, we use Linux-based fd timer
             // to wake the current process. This has downsides, some devices do not support file descriptors like windows
             // and macOS. If the timeout is null, we wait for 60 seconds until there's a new stream to select.
             $this->timerFd->setTimeout($timeout !== null ? $timeout : 60_000);
 
             $select = stream_select($read, $write, $except, null);
-        } else {
+        }else{
             $select = stream_select($read, $write, $except, $timeout === null ? null : 0, $timeout ?? 0);
         }
 
@@ -260,12 +259,12 @@ abstract class QuicheSocket{
 
     /**
      * @param resource $stream
-     * @param Closure $callback function() : void
+     * @param Closure  $callback function() : void
      *
      * @return bool whether the socket was registered
      */
-    public function registerStream($stream, Closure $callback): bool{
-        if(isset($this->nonWritableSockets[$socketId = (int)$stream])){
+    public function registerStream($stream, Closure $callback) : bool{
+        if(isset($this->nonWritableSockets[$socketId = (int) $stream])){
             return false;
         }
 

--- a/src/NetherGames/Quiche/socket/QuicheSocket.php
+++ b/src/NetherGames/Quiche/socket/QuicheSocket.php
@@ -44,7 +44,7 @@ abstract class QuicheSocket{
     private array $streams = [];
     /** @var array<int, Socket> */
     private array $nonWritableSockets = [];
-    /** @var array<int, Socket> */
+    /** @var array<int, resource> */
     private array $nonWritableStreams = [];
     /** @var array<int, Closure> */
     private array $nonWritableCallbacks = [];

--- a/src/NetherGames/Quiche/socket/QuicheSocket.php
+++ b/src/NetherGames/Quiche/socket/QuicheSocket.php
@@ -182,7 +182,7 @@ abstract class QuicheSocket{
             // Set timeout for the file descriptor. Instead of using stream_select for sleep, we use Linux-based fd timer
             // to wake the current process. This has downsides, some devices do not support file descriptors like windows
             // and macOS. If the timeout is null, we wait for 60 seconds until there's a new stream to select.
-            $this->timerFd->setTimeout($timeout !== null ? $timeout : 60_000);
+            $this->timerFd->setTimeout($timeout === null ? 60_000 : $timeout);
 
             $select = stream_select($read, $write, $except, null);
         }else{

--- a/src/NetherGames/Quiche/socket/QuicheSocket.php
+++ b/src/NetherGames/Quiche/socket/QuicheSocket.php
@@ -11,11 +11,11 @@ use NetherGames\Quiche\bindings\string_;
 use NetherGames\Quiche\bindings\uint8_t_ptr;
 use NetherGames\Quiche\Config;
 use NetherGames\Quiche\io\Timer;
+use NetherGames\Quiche\io\TimerFd;
 use NetherGames\Quiche\QuicheConnection;
 use NetherGames\Quiche\SocketAddress;
 use RuntimeException;
 use Socket;
-use Throwable;
 use function array_values;
 use function min;
 use function socket_bind;
@@ -25,7 +25,6 @@ use function socket_last_error;
 use function socket_set_nonblock;
 use function socket_strerror;
 use function spl_object_id;
-use function usleep;
 use const SOCK_DGRAM;
 use const SOL_UDP;
 
@@ -37,11 +36,16 @@ abstract class QuicheSocket{
     protected QuicheFFI $bindings;
     protected Config $config;
     public readonly Timer $timer;
+    public readonly TimerFd $timerFd;
 
     /** @var array<int, Socket> */
     private array $sockets = [];
+    /** @var array<int, resource> */
+    private array $streams = [];
     /** @var array<int, Socket> */
     private array $nonWritableSockets = [];
+    /** @var array<int, Socket> */
+    private array $nonWritableStreams = [];
     /** @var array<int, Closure> */
     private array $nonWritableCallbacks = [];
     /** @var array<int, Closure> */
@@ -63,6 +67,12 @@ abstract class QuicheSocket{
         $this->tempBuffer = uint8_t_ptr::array(self::SEND_BUFFER_SIZE);
         $this->timer = new Timer(static function(QuicheConnection $connection) : void{
             $connection->onTimeout();
+        });
+
+        // File descriptor timer
+        $this->timerFd = new TimerFd();
+        $this->registerStream($this->timerFd->getStream(), function(): void{
+            $this->timerFd->read();
         });
 
         if($enableDebugLogging){
@@ -160,27 +170,30 @@ abstract class QuicheSocket{
     abstract public function setNonWritableSocket(int $socketId) : void;
 
     public function selectSockets(?int $timeout = null) : void{
-        foreach($this->nonWritableCallbacks as $closure){
-            try {
-                $closure();
-            }catch (Throwable){}
-        }
-        foreach($this->socketCallbacks as $closure){
-            try {
-                $closure();
-            }catch (Throwable){}
-        }
+        $read = $this->streams;
+        $write = $this->nonWritableStreams;
+        $except = null;
 
         $timerWait = $this->timer->manage();
-        if($timeout === null){
+        if ($timeout === null) {
             $timeout = $timerWait;
-        }elseif($timerWait !== null){
+        } elseif ($timerWait !== null) {
             $timeout = min($timerWait, $timeout);
         }
 
-        $timeout = min($timeout, 100);
-        if($timeout !== null && $timeout > 0){
-            usleep($timeout * 1000);
+        // Set timeout for the file descriptor. Instead of using stream_select for sleep, we use Linux-based fd timer
+        // to wake the current process. This has downsides, some devices do not support file descriptors like windows
+        // and macOS. If the timeout is null, we wait for 60 seconds until there's a new stream to select.
+        $this->timerFd->setTimeout($timeout !== null ? $timeout : 60_000);
+
+        $select = stream_select($read, $write, $except, null);
+        if($select !== false && $select > 0){
+            foreach($write as $socketId => $socket){
+                $this->nonWritableCallbacks[$socketId]();
+            }
+            foreach($read as $socketId => $socket){
+                $this->socketCallbacks[$socketId]();
+            }
         }
 
         $this->handleOutgoing();
@@ -191,7 +204,7 @@ abstract class QuicheSocket{
     }
 
     public function removeNonWritableSocket(int $socketId) : void{
-        unset($this->nonWritableSockets[$socketId], $this->nonWritableCallbacks[$socketId]);
+        unset($this->nonWritableSockets[$socketId], $this->nonWritableStreams[$socketId], $this->nonWritableCallbacks[$socketId]);
     }
 
     /**
@@ -205,6 +218,7 @@ abstract class QuicheSocket{
         }
 
         $this->nonWritableSockets[$socketId] = $socket;
+        $this->nonWritableStreams[$socketId] = socket_import_stream($socket);
         $this->nonWritableCallbacks[$socketId] = $callback;
 
         return true;
@@ -227,6 +241,24 @@ abstract class QuicheSocket{
         socket_set_nonblock($socket);
 
         $this->sockets[$socketId] = $socket;
+        $this->streams[$socketId] = socket_export_stream($socket);
+        $this->socketCallbacks[$socketId] = $callback;
+
+        return true;
+    }
+
+    /**
+     * @param resource $stream
+     * @param Closure $callback function() : void
+     *
+     * @return bool whether the socket was registered
+     */
+    public function registerStream($stream, Closure $callback): bool{
+        if(isset($this->nonWritableSockets[$socketId = (int)$stream])){
+            return false;
+        }
+
+        $this->streams[$socketId] = $stream;
         $this->socketCallbacks[$socketId] = $callback;
 
         return true;

--- a/src/NetherGames/Quiche/socket/QuicheSocket.php
+++ b/src/NetherGames/Quiche/socket/QuicheSocket.php
@@ -70,10 +70,7 @@ abstract class QuicheSocket{
         });
 
         // File descriptor timer
-        $this->timerFd = new TimerFd();
-        $this->registerStream($this->timerFd->getStream(), function(): void{
-            $this->timerFd->read();
-        });
+        $this->timerFd = new TimerFd($this);
 
         if($enableDebugLogging){
             $this->bindings->getFFI()->quiche_enable_debug_logging(function(CData $a){
@@ -146,6 +143,7 @@ abstract class QuicheSocket{
 
         $this->sockets = [];
         $this->socketCallbacks = [];
+        $this->timerFd->close();
 
         $this->closed = true;
     }
@@ -181,12 +179,17 @@ abstract class QuicheSocket{
             $timeout = min($timerWait, $timeout);
         }
 
-        // Set timeout for the file descriptor. Instead of using stream_select for sleep, we use Linux-based fd timer
-        // to wake the current process. This has downsides, some devices do not support file descriptors like windows
-        // and macOS. If the timeout is null, we wait for 60 seconds until there's a new stream to select.
-        $this->timerFd->setTimeout($timeout !== null ? $timeout : 60_000);
+        if ($this->timerFd->getTimerFdId() !== -1) {
+            // Set timeout for the file descriptor. Instead of using stream_select for sleep, we use Linux-based fd timer
+            // to wake the current process. This has downsides, some devices do not support file descriptors like windows
+            // and macOS. If the timeout is null, we wait for 60 seconds until there's a new stream to select.
+            $this->timerFd->setTimeout($timeout !== null ? $timeout : 60_000);
 
-        $select = stream_select($read, $write, $except, null);
+            $select = stream_select($read, $write, $except, null);
+        } else {
+            $select = stream_select($read, $write, $except, $timeout === null ? null : 0, $timeout ?? 0);
+        }
+
         if($select !== false && $select > 0){
             foreach($write as $socketId => $socket){
                 $this->nonWritableCallbacks[$socketId]();
@@ -218,8 +221,12 @@ abstract class QuicheSocket{
         }
 
         $this->nonWritableSockets[$socketId] = $socket;
-        $this->nonWritableStreams[$socketId] = socket_import_stream($socket);
         $this->nonWritableCallbacks[$socketId] = $callback;
+
+        $stream = socket_export_stream($socket);
+        if(is_resource($stream)){
+            $this->nonWritableStreams[$socketId] = $stream;
+        }
 
         return true;
     }
@@ -241,8 +248,12 @@ abstract class QuicheSocket{
         socket_set_nonblock($socket);
 
         $this->sockets[$socketId] = $socket;
-        $this->streams[$socketId] = socket_export_stream($socket);
         $this->socketCallbacks[$socketId] = $callback;
+
+        $stream = socket_export_stream($socket);
+        if(is_resource($stream)){
+            $this->streams[$socketId] = $stream;
+        }
 
         return true;
     }


### PR DESCRIPTION
This PR aims to improve code efficiency by delegating timeout from `socket_select` into [`timerfd`](https://man7.org/linux/man-pages/man2/timerfd_create.2.html).